### PR TITLE
Change CDN links to protocol-relative

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,8 +6,8 @@
 		<link rel="stylesheet" type="text/css" href="style.css" />
 		<link rel="stylesheet" type="text/css" href="font/css/fontello.css" />
 		<script type="text/javascript" src="js/modernizr.custom.04022.js"></script>
-		<link href='http://fonts.googleapis.com/css?family=Open+Sans:400italic,600italic,400,600,700' rel='stylesheet' type='text/css'>
-		<script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js"></script>
+		<link href='//fonts.googleapis.com/css?family=Open+Sans:400italic,600italic,400,600,700' rel='stylesheet' type='text/css'>
+		<script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js"></script>
 		<script type="text/javascript" src="js/jquery.cookie.js"></script>
 		<script>
 			var last_tabs_radio;


### PR DESCRIPTION
Needed since GitHub Pages is now strictly HTTPS by default